### PR TITLE
Staff Roles Endpoints

### DIFF
--- a/backend/scripts/modules/repository.template.txt
+++ b/backend/scripts/modules/repository.template.txt
@@ -1,8 +1,9 @@
-import * as v from 'valibot';
 import type { DatabaseClient } from '$src/types';
 
-async function myFunction(db: DatabaseClient) {
-  return db;
+class {$1}Repository {
+  public myFunction(db: DatabaseClient) {
+    return db;
+  }
 }
 
-export const {$1}Repository = {  };
+export const {$2}Repository = new {$3}Repository();

--- a/backend/scripts/modules/service.template.txt
+++ b/backend/scripts/modules/service.template.txt
@@ -1,7 +1,13 @@
-import * as v from 'valibot';
+import { Service } from '$src/utils/service';
 import { {$1}Repository } from './repository';
-import { {$2}Validation } from './validation';
+import type { DatabaseClient } from '$src/types';
+import type { {$2}ValidationInput, {$3}ValidationOutput } from './validation';
 
+class {$4}Service extends Service {
+    public async myFunction(db: DatabaseClient) {
+        const fn = this.createServiceFunction('My function');
+        return {$5}Repository.myFunction(db);
+    }
+}
 
-
-export const {$3}Service = {  };
+export const {$6}Service = new {$7}Service();

--- a/backend/scripts/modules/validation.template.txt
+++ b/backend/scripts/modules/validation.template.txt
@@ -1,6 +1,12 @@
 import * as v from 'valibot';
 import * as s from '$src/utils/validation';
+import type { MapInput, MapOutput } from '$src/types';
 
+export abstract class {$1}Validation {
+  public static myValidation = v.object({
+    myField: v.string()
+  });
+}
 
-
-export const {$1}Validation = {  };
+export type {$2}ValidationInput = MapInput<typeof {$3}Validation>;
+export type {$4}ValidationOutput = MapOutput<typeof {$5}Validation>;

--- a/backend/scripts/modules/write-file.ts
+++ b/backend/scripts/modules/write-file.ts
@@ -6,7 +6,12 @@ export async function writeRepositoryFile(folder: string) {
     `${process.cwd()}/src/modules/${folder}/repository.ts`,
     await Bun.file(`${process.cwd()}/scripts/modules/repository.template.txt`)
       .text()
-      .then((txt) => txt.replace('{$1}', camelCase(folder)))
+      .then((txt) =>
+        txt
+          .replace('{$1}', pascalCase(folder))
+          .replace('{$2}', camelCase(folder))
+          .replace('{$3}', pascalCase(folder))
+      )
   );
 }
 
@@ -19,7 +24,11 @@ export async function writeServiceFile(folder: string) {
         txt
           .replace('{$1}', camelCase(folder))
           .replace('{$2}', pascalCase(folder))
-          .replace('{$3}', camelCase(folder))
+          .replace('{$3}', pascalCase(folder))
+          .replace('{$4}', pascalCase(folder))
+          .replace('{$5}', camelCase(folder))
+          .replace('{$6}', camelCase(folder))
+          .replace('{$7}', pascalCase(folder))
       )
   );
 }
@@ -29,6 +38,13 @@ export async function writeValidationFile(folder: string) {
     `${process.cwd()}/src/modules/${folder}/validation.ts`,
     await Bun.file(`${process.cwd()}/scripts/modules/validation.template.txt`)
       .text()
-      .then((txt) => txt.replace('{$1}', pascalCase(folder)))
+      .then((txt) =>
+        txt
+          .replace('{$1}', pascalCase(folder))
+          .replace('{$2}', pascalCase(folder))
+          .replace('{$3}', pascalCase(folder))
+          .replace('{$4}', pascalCase(folder))
+          .replace('{$5}', pascalCase(folder))
+      )
   );
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from 'hono/cors';
 import { devRouter } from '$src/routers/dev.ts';
 import { tournamentRouter } from '$src/routers/tournament';
 import { authRouter } from './routers/auth';
+import { staffRoleRouter } from './routers/staff-role';
 import { env } from './utils/env';
 
 const app = new Hono()
@@ -15,7 +16,8 @@ const app = new Hono()
   )
   .route('/', authRouter)
   .route('/', tournamentRouter)
-  .route('/', devRouter);
+  .route('/', devRouter)
+  .route('/', staffRoleRouter);
 
 export default app;
 export type App = typeof app;

--- a/backend/src/modules/staff-role/repository.ts
+++ b/backend/src/modules/staff-role/repository.ts
@@ -1,0 +1,52 @@
+import { eq } from 'drizzle-orm';
+import { StaffRole } from '$src/schema';
+import { pick } from '$src/utils/query';
+import type { DatabaseClient, Selection } from '$src/types';
+import type { StaffRoleValidationOutput } from './validation';
+
+class StaffRoleRepository {
+  public async getStaffRole<T extends Selection<typeof StaffRole>>(
+    db: DatabaseClient,
+    staffRoleId: number,
+    select: T
+  ) {
+    return db
+      .select(pick(StaffRole, select))
+      .from(StaffRole)
+      .where(eq(StaffRole.id, staffRoleId))
+      .then((rows) => rows[0]);
+  }
+
+  public async createStaffRole(
+    db: DatabaseClient,
+    staffRole: StaffRoleValidationOutput['CreateStaffRole'],
+    order: number
+  ) {
+    return db
+      .insert(StaffRole)
+      .values({
+        ...staffRole,
+        order
+      })
+      .returning(
+        pick(StaffRole, {
+          id: true
+        })
+      )
+      .then((rows) => rows[0]);
+  }
+
+  public async updateStaffRole(
+    db: DatabaseClient,
+    staffRoleId: number,
+    staffRole: StaffRoleValidationOutput['UpdateStaffRole']
+  ) {
+    return db.update(StaffRole).set(staffRole).where(eq(StaffRole.id, staffRoleId));
+  }
+
+  public async getStaffRoleCount(db: DatabaseClient, tournamentId: number) {
+    return db.$count(StaffRole, eq(StaffRole.tournamentId, tournamentId));
+  }
+}
+
+export const staffRoleRepository = new StaffRoleRepository();

--- a/backend/src/modules/staff-role/repository.ts
+++ b/backend/src/modules/staff-role/repository.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { StaffRole } from '$src/schema';
 import { pick } from '$src/utils/query';
 import type { DatabaseClient, Selection } from '$src/types';
@@ -15,6 +15,18 @@ class StaffRoleRepository {
       .from(StaffRole)
       .where(eq(StaffRole.id, staffRoleId))
       .then((rows) => rows[0]);
+  }
+
+  public async getStaffRoles<T extends Selection<typeof StaffRole>>(
+    db: DatabaseClient,
+    staffRoleIds: number[],
+    select: T
+  ) {
+    return db
+      .select(pick(StaffRole, select))
+      .from(StaffRole)
+      .where(and(inArray(StaffRole.id, staffRoleIds)))
+      .then((rows) => rows);
   }
 
   public async createStaffRole(
@@ -44,8 +56,24 @@ class StaffRoleRepository {
     return db.update(StaffRole).set(staffRole).where(eq(StaffRole.id, staffRoleId));
   }
 
+  public async deleteStaffRole<T extends Selection<typeof StaffRole>>(
+    db: DatabaseClient,
+    staffRoleId: number,
+    returning: T
+  ) {
+    return db
+      .delete(StaffRole)
+      .where(eq(StaffRole.id, staffRoleId))
+      .returning(pick(StaffRole, returning))
+      .then((rows) => rows[0]);
+  }
+
   public async getStaffRoleCount(db: DatabaseClient, tournamentId: number) {
     return db.$count(StaffRole, eq(StaffRole.tournamentId, tournamentId));
+  }
+
+  public async updateStaffRoleOrder(db: DatabaseClient, staffRoleId: number, order: number) {
+    return await db.update(StaffRole).set({ order }).where(eq(StaffRole.id, staffRoleId));
   }
 }
 

--- a/backend/src/modules/staff-role/repository.ts
+++ b/backend/src/modules/staff-role/repository.ts
@@ -8,12 +8,13 @@ class StaffRoleRepository {
   public async getStaffRole<T extends Selection<typeof StaffRole>>(
     db: DatabaseClient,
     staffRoleId: number,
+    tournamentId: number,
     select: T
   ) {
     return db
       .select(pick(StaffRole, select))
       .from(StaffRole)
-      .where(eq(StaffRole.id, staffRoleId))
+      .where(and(eq(StaffRole.id, staffRoleId), eq(StaffRole.tournamentId, tournamentId)))
       .then((rows) => rows[0]);
   }
 

--- a/backend/src/modules/staff-role/service.ts
+++ b/backend/src/modules/staff-role/service.ts
@@ -1,0 +1,78 @@
+import { HTTPException } from 'hono/http-exception';
+import { StaffRole } from '$src/schema';
+import { isUniqueConstraintViolationError, unknownError } from '$src/utils/error';
+import { Service } from '$src/utils/service';
+import { tournamentService } from '../tournament/service';
+import { staffRoleRepository } from './repository';
+import type { DatabaseClient } from '$src/types';
+import type { StaffRoleValidationOutput } from './validation';
+
+//TODO: implement staff member permissions check once implemented
+class StaffRoleService extends Service {
+  private MAX_STAFF_ROLES = 25;
+
+  public async createStaffRole(
+    db: DatabaseClient,
+    input: StaffRoleValidationOutput['CreateStaffRole']
+  ) {
+    const fn = this.createServiceFunction('Failed to create staff role');
+    const tournamentAvailable = await tournamentService.checkTournamentAvailability(
+      db,
+      input.tournamentId
+    );
+
+    if (!tournamentAvailable) {
+      throw new HTTPException(403, {
+        message: 'Tournament has already concluded or is deleted'
+      });
+    }
+
+    const staffRolesCount = await staffRoleRepository.getStaffRoleCount(db, input.tournamentId);
+
+    if (staffRolesCount >= this.MAX_STAFF_ROLES) {
+      throw new HTTPException(403, {
+        message: "Can't have more than 25 staff roles per tournament"
+      });
+    }
+
+    return await fn.handleDbQuery(
+      staffRoleRepository.createStaffRole(db, input, staffRolesCount + 1),
+      this.handleStaffRoleCreationError(input.name, fn.errorMessage)
+    );
+  }
+
+  public async updateStaffRole(
+    db: DatabaseClient,
+    input: StaffRoleValidationOutput['UpdateStaffRole'],
+    staffRoleId: number
+  ) {
+    const fn = this.createServiceFunction('Failed to update staff role');
+
+    const existingStaffRole = await staffRoleRepository.getStaffRole(db, staffRoleId, {
+      id: true
+    });
+
+    if (!existingStaffRole) {
+      throw new HTTPException(404, {
+        message: 'Staff role not found'
+      });
+    }
+
+    await fn.handleDbQuery(staffRoleRepository.updateStaffRole(db, staffRoleId, input));
+  }
+
+  private handleStaffRoleCreationError(staffRoleName: string, descriptionIfUnknownError: string) {
+    return (err: unknown): never => {
+      if (isUniqueConstraintViolationError(err, [StaffRole.name])) {
+        throw new HTTPException(409, {
+          message: `Staff role '${staffRoleName}' already exists for this tournament`
+        });
+      }
+
+      unknownError(descriptionIfUnknownError)(err);
+      return undefined as never;
+    };
+  }
+}
+
+export const staffRoleService = new StaffRoleService();

--- a/backend/src/modules/staff-role/service.ts
+++ b/backend/src/modules/staff-role/service.ts
@@ -49,9 +49,14 @@ class StaffRoleService extends Service {
   ) {
     const fn = this.createServiceFunction('Failed to update staff role');
 
-    const existingStaffRole = await staffRoleRepository.getStaffRole(db, staffRoleId, {
-      id: true
-    });
+    const existingStaffRole = await staffRoleRepository.getStaffRole(
+      db,
+      staffRoleId,
+      input.tournamentId,
+      {
+        id: true
+      }
+    );
 
     if (!existingStaffRole) {
       throw new HTTPException(404, {
@@ -86,12 +91,12 @@ class StaffRoleService extends Service {
     }
 
     const [sourceStaffRole, targetStaffRole] = await Promise.all([
-      staffRoleRepository.getStaffRole(db, sourceStaffRoleId, {
+      staffRoleRepository.getStaffRole(db, sourceStaffRoleId, tournamentId, {
         id: true,
         order: true,
         tournamentId: true
       }),
-      staffRoleRepository.getStaffRole(db, targetStaffRoleId, {
+      staffRoleRepository.getStaffRole(db, targetStaffRoleId, tournamentId, {
         id: true,
         order: true,
         tournamentId: true
@@ -126,13 +131,18 @@ class StaffRoleService extends Service {
     );
   }
 
-  public async deleteStaffRole(db: DatabaseClient, staffRoleId: number) {
+  public async deleteStaffRole(db: DatabaseClient, staffRoleId: number, tournamentId: number) {
     const fn = this.createServiceFunction('Failed to delete staff role');
 
-    const existingStaffRole = await staffRoleRepository.getStaffRole(db, staffRoleId, {
-      order: true,
-      tournamentId: true
-    });
+    const existingStaffRole = await staffRoleRepository.getStaffRole(
+      db,
+      staffRoleId,
+      tournamentId,
+      {
+        order: true,
+        tournamentId: true
+      }
+    );
 
     if (!existingStaffRole) {
       throw new HTTPException(404, {

--- a/backend/src/modules/staff-role/service.ts
+++ b/backend/src/modules/staff-role/service.ts
@@ -1,3 +1,4 @@
+import { and, eq, gt, sql } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { StaffRole } from '$src/schema';
 import { isUniqueConstraintViolationError, unknownError } from '$src/utils/error';
@@ -58,7 +59,106 @@ class StaffRoleService extends Service {
       });
     }
 
-    await fn.handleDbQuery(staffRoleRepository.updateStaffRole(db, staffRoleId, input));
+    await fn.handleDbQuery(
+      staffRoleRepository.updateStaffRole(db, staffRoleId, input),
+      input.name ? this.handleStaffRoleCreationError(input.name, fn.errorMessage) : undefined
+    );
+  }
+
+  public async swapStaffRoles(
+    db: DatabaseClient,
+    input: StaffRoleValidationOutput['SwapStaffRoles'],
+    sourceStaffRoleId: number
+  ) {
+    const fn = this.createServiceFunction('Failed to swap staff roles');
+
+    const { tournamentId, targetStaffRoleId } = input;
+
+    const tournamentAvailable = await tournamentService.checkTournamentAvailability(
+      db,
+      tournamentId
+    );
+
+    if (!tournamentAvailable) {
+      throw new HTTPException(403, {
+        message: 'Tournament has already concluded or is deleted'
+      });
+    }
+
+    const [sourceStaffRole, targetStaffRole] = await Promise.all([
+      staffRoleRepository.getStaffRole(db, sourceStaffRoleId, {
+        id: true,
+        order: true,
+        tournamentId: true
+      }),
+      staffRoleRepository.getStaffRole(db, targetStaffRoleId, {
+        id: true,
+        order: true,
+        tournamentId: true
+      })
+    ]);
+
+    if (!sourceStaffRole || !targetStaffRole) {
+      throw new HTTPException(404, {
+        message: 'Staff role not found'
+      });
+    }
+
+    if (sourceStaffRole.tournamentId !== targetStaffRole.tournamentId) {
+      throw new HTTPException(403, {
+        message: 'Staff roles must belong in the same tournament'
+      });
+    }
+
+    await fn.handleDbQuery(
+      db.transaction(async (tx) => {
+        await staffRoleRepository.updateStaffRoleOrder(
+          tx,
+          sourceStaffRole.id,
+          targetStaffRole.order
+        );
+        await staffRoleRepository.updateStaffRoleOrder(
+          tx,
+          targetStaffRole.id,
+          sourceStaffRole.order
+        );
+      })
+    );
+  }
+
+  public async deleteStaffRole(db: DatabaseClient, staffRoleId: number) {
+    const fn = this.createServiceFunction('Failed to delete staff role');
+
+    const existingStaffRole = await staffRoleRepository.getStaffRole(db, staffRoleId, {
+      order: true,
+      tournamentId: true
+    });
+
+    if (!existingStaffRole) {
+      throw new HTTPException(404, {
+        message: 'Staff role not found'
+      });
+    }
+
+    await fn.handleDbQuery(
+      db.transaction(async (tx) => {
+        const deletedStaffRole = await staffRoleRepository.deleteStaffRole(tx, staffRoleId, {
+          order: true
+        });
+
+        await tx
+          .update(StaffRole)
+          .set({
+            order: sql<number>`${StaffRole.order} - 1`
+          })
+          .where(
+            and(
+              eq(StaffRole.tournamentId, existingStaffRole.tournamentId),
+              gt(StaffRole.order, deletedStaffRole.order)
+            )
+          );
+      })
+    );
   }
 
   private handleStaffRoleCreationError(staffRoleName: string, descriptionIfUnknownError: string) {

--- a/backend/src/modules/staff-role/validation.ts
+++ b/backend/src/modules/staff-role/validation.ts
@@ -24,20 +24,23 @@ export abstract class StaffRoleValidation {
         'pink'
       ]),
       'slate'
-    )
-  });
-
-  public static CreateStaffRole = v.object({
-    ...this.BaseMutateStaffRole.entries,
+    ),
     tournamentId: s.integerId()
   });
 
-  public static UpdateStaffRole = v.partial(
-    v.object({
-      ...this.BaseMutateStaffRole.entries,
-      permissions: v.array(v.picklist(StaffPermission.enumValues))
-    })
-  );
+  public static CreateStaffRole = v.object({
+    ...this.BaseMutateStaffRole.entries
+  });
+
+  public static UpdateStaffRole = v.object({
+    ...v.pick(this.BaseMutateStaffRole, ['tournamentId']).entries,
+    ...v.partial(
+      v.object({
+        ...v.omit(this.BaseMutateStaffRole, ['tournamentId']).entries,
+        permissions: v.array(v.picklist(StaffPermission.enumValues))
+      })
+    ).entries
+  });
 
   public static SwapStaffRoles = v.object({
     tournamentId: s.integerId(),

--- a/backend/src/modules/staff-role/validation.ts
+++ b/backend/src/modules/staff-role/validation.ts
@@ -32,9 +32,16 @@ export abstract class StaffRoleValidation {
     tournamentId: s.integerId()
   });
 
-  public static UpdateStaffRole = v.object({
-    ...this.BaseMutateStaffRole.entries,
-    permissions: v.array(v.picklist(StaffPermission.enumValues))
+  public static UpdateStaffRole = v.partial(
+    v.object({
+      ...this.BaseMutateStaffRole.entries,
+      permissions: v.array(v.picklist(StaffPermission.enumValues))
+    })
+  );
+
+  public static SwapStaffRoles = v.object({
+    tournamentId: s.integerId(),
+    targetStaffRoleId: s.integerId()
   });
 }
 

--- a/backend/src/modules/staff-role/validation.ts
+++ b/backend/src/modules/staff-role/validation.ts
@@ -1,0 +1,42 @@
+import * as v from 'valibot';
+import { StaffPermission } from '$src/schema';
+import * as s from '$src/utils/validation';
+import type { MapInput, MapOutput } from '$src/types';
+
+export abstract class StaffRoleValidation {
+  public static BaseMutateStaffRole = v.object({
+    name: s.nonEmptyString(),
+    color: v.optional(
+      v.picklist([
+        'slate',
+        'gray',
+        'red',
+        'orange',
+        'yellow',
+        'lime',
+        'green',
+        'emerald',
+        'cyan',
+        'blue',
+        'indigo',
+        'purple',
+        'fuchsia',
+        'pink'
+      ]),
+      'slate'
+    )
+  });
+
+  public static CreateStaffRole = v.object({
+    ...this.BaseMutateStaffRole.entries,
+    tournamentId: s.integerId()
+  });
+
+  public static UpdateStaffRole = v.object({
+    ...this.BaseMutateStaffRole.entries,
+    permissions: v.array(v.picklist(StaffPermission.enumValues))
+  });
+}
+
+export type StaffRoleValidationInput = MapInput<typeof StaffRoleValidation>;
+export type StaffRoleValidationOutput = MapOutput<typeof StaffRoleValidation>;

--- a/backend/src/modules/tournament/service.ts
+++ b/backend/src/modules/tournament/service.ts
@@ -197,6 +197,26 @@ class TournamentService extends Service {
     await fn.handleDbQuery(tournamentRepository.softDeleteTournament(db, tournamentId, deleteAt));
   }
 
+  public async checkTournamentAvailability(db: DatabaseClient, tournamentId: number) {
+    const tournament = await tournamentRepository.getTournament(db, tournamentId, {
+      deletedAt: true,
+      concludedAt: true
+    });
+
+    if (!tournament) {
+      throw new HTTPException(404, {
+        message: 'Tournament does not exist'
+      });
+    }
+
+    const now = new Date();
+
+    const tournamentDeleted = tournament.deletedAt && tournament.deletedAt <= now;
+    const tournamentConcluded = tournament.concludedAt && tournament.concludedAt <= now;
+
+    return !(tournamentConcluded || tournamentDeleted);
+  }
+
   private handleTournamentCreationError(
     tournament: { name: string; urlSlug: string },
     descriptionIfUnknownError: string

--- a/backend/src/routers/staff-role.ts
+++ b/backend/src/routers/staff-role.ts
@@ -58,13 +58,20 @@ export const staffRoleRouter = new Hono()
     vValidator(
       'param',
       v.object({
-        staffRoleId: s.stringToInteger()
+        staffRoleId: s.integerId()
+      })
+    ),
+    vValidator(
+      'query',
+      v.object({
+        tournamentId: s.stringToInteger()
       })
     ),
     async (c) => {
       const { staffRoleId } = c.req.valid('param');
+      const { tournamentId } = c.req.valid('query');
 
-      await staffRoleService.deleteStaffRole(db, staffRoleId);
+      await staffRoleService.deleteStaffRole(db, staffRoleId, tournamentId);
 
       return c.json({ message: 'Staff role deleted' });
     }

--- a/backend/src/routers/staff-role.ts
+++ b/backend/src/routers/staff-role.ts
@@ -2,14 +2,18 @@ import { vValidator } from '@hono/valibot-validator';
 import { Hono } from 'hono';
 import * as v from 'valibot';
 import { sessionMiddleware } from '$src/middlewares/session';
+import { staffRoleService } from '$src/modules/staff-role/service';
 import { StaffRoleValidation } from '$src/modules/staff-role/validation';
+import { db } from '$src/singletons';
 import * as s from '$src/utils/validation';
 
 export const staffRoleRouter = new Hono()
   .basePath('staff/role')
   .use(sessionMiddleware())
   .post('/', vValidator('json', StaffRoleValidation.CreateStaffRole), async (c) => {
-    const _body = c.req.valid('json');
+    const body = c.req.valid('json');
+
+    await staffRoleService.createStaffRole(db, body);
 
     return c.json({ message: 'Staff role created' });
   })
@@ -23,9 +27,45 @@ export const staffRoleRouter = new Hono()
     ),
     vValidator('json', StaffRoleValidation.UpdateStaffRole),
     async (c) => {
-      const _params = c.req.valid('param');
-      const _body = c.req.valid('json');
+      const { staffRoleId } = c.req.valid('param');
+      const body = c.req.valid('json');
+
+      await staffRoleService.updateStaffRole(db, body, staffRoleId);
 
       return c.json({ message: 'Staff role updated' });
+    }
+  )
+  .patch(
+    '/:staffRoleId/order',
+    vValidator(
+      'param',
+      v.object({
+        staffRoleId: s.stringToInteger()
+      })
+    ),
+    vValidator('json', StaffRoleValidation.SwapStaffRoles),
+    async (c) => {
+      const { staffRoleId } = c.req.valid('param');
+      const body = c.req.valid('json');
+
+      await staffRoleService.swapStaffRoles(db, body, staffRoleId);
+
+      return c.json({ message: 'Staff role orders swapped' });
+    }
+  )
+  .delete(
+    '/:staffRoleId',
+    vValidator(
+      'param',
+      v.object({
+        staffRoleId: s.stringToInteger()
+      })
+    ),
+    async (c) => {
+      const { staffRoleId } = c.req.valid('param');
+
+      await staffRoleService.deleteStaffRole(db, staffRoleId);
+
+      return c.json({ message: 'Staff role deleted' });
     }
   );

--- a/backend/src/routers/staff-role.ts
+++ b/backend/src/routers/staff-role.ts
@@ -1,0 +1,31 @@
+import { vValidator } from '@hono/valibot-validator';
+import { Hono } from 'hono';
+import * as v from 'valibot';
+import { sessionMiddleware } from '$src/middlewares/session';
+import { StaffRoleValidation } from '$src/modules/staff-role/validation';
+import * as s from '$src/utils/validation';
+
+export const staffRoleRouter = new Hono()
+  .basePath('staff/role')
+  .use(sessionMiddleware())
+  .post('/', vValidator('json', StaffRoleValidation.CreateStaffRole), async (c) => {
+    const _body = c.req.valid('json');
+
+    return c.json({ message: 'Staff role created' });
+  })
+  .patch(
+    '/:staffRoleId',
+    vValidator(
+      'param',
+      v.object({
+        staffRoleId: s.stringToInteger()
+      })
+    ),
+    vValidator('json', StaffRoleValidation.UpdateStaffRole),
+    async (c) => {
+      const _params = c.req.valid('param');
+      const _body = c.req.valid('json');
+
+      return c.json({ message: 'Staff role updated' });
+    }
+  );

--- a/backend/src/schema/registrations.ts
+++ b/backend/src/schema/registrations.ts
@@ -1,32 +1,45 @@
-import { integer, pgTable, primaryKey, smallint, text, timestamp, unique, varchar } from 'drizzle-orm/pg-core';
+import {
+  integer,
+  pgTable,
+  primaryKey,
+  smallint,
+  text,
+  timestamp,
+  unique,
+  varchar
+} from 'drizzle-orm/pg-core';
 import { StaffPermission } from './enums';
 import { Tournament } from './tournaments';
-import { timestampConfig } from './utils';
 import { User } from './users';
+import { timestampConfig } from './utils';
 
 export const StaffRole = pgTable(
   'staff_role',
   {
     id: integer().generatedAlwaysAsIdentity().primaryKey(),
     createdAt: timestamp('created_at', timestampConfig).notNull().defaultNow(),
-    deletedAt: timestamp('deleted_at', timestampConfig),
+    updatedAt: timestamp('updated_at', timestampConfig).notNull().defaultNow(),
     name: varchar('name', { length: 50 }).notNull(),
-    color: text({ enum: [
-      'slate',
-      'gray',
-      'red',
-      'orange',
-      'yellow',
-      'lime',
-      'green',
-      'emerald',
-      'cyan',
-      'blue',
-      'indigo',
-      'purple',
-      'fuchsia',
-      'pink'
-    ] }).notNull().default('slate'),
+    color: text({
+      enum: [
+        'slate',
+        'gray',
+        'red',
+        'orange',
+        'yellow',
+        'lime',
+        'green',
+        'emerald',
+        'cyan',
+        'blue',
+        'indigo',
+        'purple',
+        'fuchsia',
+        'pink'
+      ]
+    })
+      .notNull()
+      .default('slate'),
     order: smallint().notNull(),
     permissions: StaffPermission().array().notNull().default([]),
     tournamentId: integer()
@@ -35,12 +48,7 @@ export const StaffRole = pgTable(
         onDelete: 'cascade'
       })
   },
-  (table) => [
-    unique('staff_role_name_tournament_id_uni').on(
-      table.name,
-      table.tournamentId
-    )
-  ]
+  (table) => [unique('staff_role_name_tournament_id_uni').on(table.name, table.tournamentId)]
 );
 
 export const StaffMember = pgTable(
@@ -58,12 +66,7 @@ export const StaffMember = pgTable(
         onDelete: 'cascade'
       })
   },
-  (table) => [
-    unique('staff_member_user_id_tournament_id_uni').on(
-      table.userId,
-      table.tournamentId
-    )
-  ]
+  (table) => [unique('staff_member_user_id_tournament_id_uni').on(table.userId, table.tournamentId)]
 );
 
 export const StaffMemberRole = pgTable(


### PR DESCRIPTION
This PR introduces `/staff/role` endpoint for managing tournament staff roles:

`[POST] /` - create staff role
`[PATCH] /:staffRoleId` - edit staff role
`[PATCH] /:staffRoleId/order` - swap staff roles order
`[DELETE] /:staffRoleId` - delete staff role

Most of this stuff will be expanded/rewritten after staff members implementation